### PR TITLE
Manual and random seeding for stages

### DIFF
--- a/frontend1/lib/tournamentEdit/stagesAccordion.tsx
+++ b/frontend1/lib/tournamentEdit/stagesAccordion.tsx
@@ -8,6 +8,11 @@ import { supabase } from '~/lib/supabase';
 export default function StagesAccordion({ tournamentId }: { tournamentId: number | null }) {
   const [divisionName, setDivisionName] = useState('');
   const [stageName, setStageName] = useState('');
+  const [teamName, setTeamName] = useState('');
+  const [seed, setSeed] = useState('');
+  const [stage, setStage] = useState('');
+
+
 
   const upsertStage = async () => {
     if (divisionName.trim() === '' || stageName.trim() === '') {
@@ -26,6 +31,57 @@ export default function StagesAccordion({ tournamentId }: { tournamentId: number
         Alert.alert('Success', 'Stage added or updated successfully!');
         setDivisionName('');
         setStageName('');
+      }
+    } catch (error) {
+      Alert.alert('Unexpected Error', (error as Error).message);
+    }
+  };
+
+  const manualSeed = async () => {
+    if (stage.trim() === '' || teamName.trim() === '' || seed.trim() === '') {
+      Alert.alert('Please enter all fields.');
+      return;
+    }
+
+    try {
+      const { error } = await supabase
+        .from('stageseeds')
+        .upsert({ stage_id: stage, team_id: teamName, seed: seed });
+
+      if (error) {
+        Alert.alert('Error', error.message);
+      } else {
+        Alert.alert('Success', 'Seed added or updated successfully!');
+        setStage('');
+        setTeamName('');
+        setSeed('');
+      }
+    } catch (error) {
+      Alert.alert('Unexpected Error', (error as Error).message);
+    }
+  };
+  
+
+  const randomSeed = async () => {
+    if (stage.trim() === '') {
+      Alert.alert('Please enter a stage ID.');
+      return;
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('stageseeds')
+        .select('*')
+        .eq('stage_id', stage);
+
+      if (error) {
+        Alert.alert('Error', error.message);
+      } else {
+        const teams = data.map((seed: { team_id: string }) => seed.team_id);
+        const shuffledTeams = teams.sort(() => Math.random() - 0.5);
+        const seeds = shuffledTeams.map((team, index) => ({ stage_id: stage, team_id: team, seed: index + 1 }));
+        await supabase.from('stageseeds').upsert(seeds);
+        Alert.alert('Success', 'Seeds randomized successfully!');
       }
     } catch (error) {
       Alert.alert('Unexpected Error', (error as Error).message);
@@ -51,6 +107,25 @@ export default function StagesAccordion({ tournamentId }: { tournamentId: number
           onChangeText={setStageName}
         />
         <Button onPress={upsertStage}>Create Stage</Button>
+        <Text>Manual Seed:</Text>
+        <Input
+          placeholder="stage"
+          value={stage}
+          onChangeText={setStage}
+        />
+        <Input
+          placeholder="team1"
+          value={teamName}
+          onChangeText={setTeamName}
+        />
+        <Input
+          placeholder="seed"
+          value={seed}
+          onChangeText={setSeed}
+        />
+        <Button onPress={manualSeed}>Add seed manually</Button>
+        <Button onPress={randomSeed}>Randomize seeds for given stage</Button>
+
       </AccordionContent>
     </AccordionItem>
   );


### PR DESCRIPTION
On edit page, tournament organizers can now maually change each seed of each team in the division and stage. Or just click randomize to give them seeds 1 - number of teams randomly assigned